### PR TITLE
cloud: fix docker hub organization name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,37 @@
-# Traffic Control Plugin for Weave Scope
+# Scope Traffic Control Plugin
 
-The Traffic Control plugin allows to modify the performance parameters of container's network interfaces using [Weave Scope](https://github.com/weaveworks/scope).
+The Scope Traffic Control plugin allows to modify the performance parameters of container's network interfaces using [Weave Scope](https://github.com/weaveworks/scope).
 The following images show a simple example of how **status** and **controls** are displayed in scope UI.
 
 <img src="imgs/container_view.png" width="200" alt="Scope Probe plugin screenshot" align="center">
 
 ## How to Run Scope Traffic Control Plugin
 
-To run the scope traffic control plugin you need just to pull the image from docker hub and you are good to go.
+* Using a pre-built Docker image
+
+If you want to make sure of running the latest available version of the plugin, you can pull the image from docker hub.
 
 ```
-docker pull weaveworks-plugins/scope-traffic-control:latest
+docker pull weaveworksplugins/scope-traffic-control:latest
+```
+
+To run the Scope Traffic Control plugin you just need to run the following command.
+
+```
 docker run --rm -it \
 			 --net=host --pid=host --privileged \
-			 -v /var/run:/var/run weaveworks-plugins/scope-traffic-control:latest
+			 -v /var/run:/var/run \
+			 --name weaveworksplugins-scope-traffic-control weaveworksplugins/scope-traffic-control:latest
 ```
 
-**Note** The traffic control plugin works with *Weave Scope*, you need to have Scope up and running before you can use it.
+* Recompiling an image
+
+```
+git clone git@github.com:weaveworks-plugins/scope-traffic-control.git
+cd scope-traffic-control; make;
+```
+
+**Note** The Scope Traffic Control plugin works with *Weave Scope*, you need to have Scope up and running before you can use it.
 If the running plugin has been registered by Scope, you will see it in the list of `PLUGINS` in the bottom right of the UI (see the rectangle in the above figure).
 
 
@@ -26,7 +41,7 @@ The parameters are shown in a table named **Traffic Control**. The plugin shows 
 
 ## Controls
 
-The Traffic Controls plugin provides a simple interface to change the value of latency (hourglass buttons) and packet loss (scissor button) or remove value that was set (circled cross button). Such buttons are displayed on the top of the container detailed view, just above the *STATUS* section (See picture below, control are shown inside the red rectangle).
+The Scope Traffic Controls plugin provides a simple interface to change the value of latency (hourglass buttons) and packet loss (scissor button) or remove value that was set (circled cross button). Such buttons are displayed on the top of the container detailed view, just above the *STATUS* section (See picture below, control are shown inside the red rectangle).
 
 <img src="imgs/controls.png" width="400" alt="Scope Probe plugin screenshot" align="center">
 


### PR DESCRIPTION
Fix docker organization name, because docker hub does not allow dashes (`-`) in the organization name.

@2opremio PTAL
